### PR TITLE
Refactor, use SourceOptions.keywordPattern and safe getbufinfo

### DIFF
--- a/denops/@ddc-sources/buffer.ts
+++ b/denops/@ddc-sources/buffer.ts
@@ -15,6 +15,7 @@ import {
   OnEventArguments,
 } from "https://deno.land/x/ddc_vim@v3.4.0/base/source.ts";
 import { basename } from "https://deno.land/std@0.187.0/path/mod.ts";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 
 type BufCache = {
   bufnr: number;
@@ -188,8 +189,9 @@ async function getBufnrs(
 ): Promise<number[]> {
   if (id !== undefined) {
     const currentBufnr = await fn.bufnr(denops);
-    return (await denops.call("denops#callback#call", id, context) as number[])
-      .map((bufnr) => bufnr !== 0 ? bufnr : currentBufnr);
+    const bufnrs = await denops.call("denops#callback#call", id, context);
+    assert(bufnrs, is.ArrayOf(is.Number));
+    return bufnrs.map((bufnr) => bufnr !== 0 ? bufnr : currentBufnr);
   } else {
     return (await fn.getbufinfo(denops))
       .filter((info) => info.listed && info.loaded)

--- a/denops/@ddc-sources/buffer.ts
+++ b/denops/@ddc-sources/buffer.ts
@@ -11,6 +11,7 @@ import {
   vars,
 } from "https://deno.land/x/ddc_vim@v3.6.0/deps.ts";
 import {
+  GatherArguments,
   OnEventArguments,
 } from "https://deno.land/x/ddc_vim@v3.4.0/base/source.ts";
 import { basename } from "https://deno.land/std@0.187.0/path/mod.ts";
@@ -31,13 +32,13 @@ type Params = {
 
 export class Source extends BaseSource<Params> {
   private buffers: Record<number, BufCache> = {};
-  override events = [
+  override events: DdcEvent[] = [
     "BufWinEnter",
     "BufWritePost",
     "InsertEnter",
     "InsertLeave",
     "BufEnter",
-  ] as DdcEvent[];
+  ];
 
   private async makeBufCache(
     denops: Denops,
@@ -115,16 +116,15 @@ export class Source extends BaseSource<Params> {
     );
   }
 
-  override async gather(args: {
-    denops: Denops;
-    context: Context;
-    sourceParams: Params;
-  }): Promise<Item[]> {
-    const param = args.sourceParams as Params;
+  override async gather({
+    denops,
+    context,
+    sourceParams,
+  }: GatherArguments<Params>): Promise<Item[]> {
     const bufnrs = await getBufnrs(
-      args.denops,
-      args.context,
-      param.getBufnrs,
+      denops,
+      context,
+      sourceParams.getBufnrs,
     );
 
     return Object.values(this.buffers)
@@ -132,9 +132,9 @@ export class Source extends BaseSource<Params> {
       .flatMap((cache): Item[] =>
         cache.candidates.map((item) => ({
           ...item,
-          menu: param.bufNameStyle === "full"
+          menu: sourceParams.bufNameStyle === "full"
             ? cache.bufname
-            : param.bufNameStyle === "basename"
+            : sourceParams.bufNameStyle === "basename"
             ? basename(cache.bufname)
             : undefined,
         }))

--- a/denops/@ddc-sources/buffer.ts
+++ b/denops/@ddc-sources/buffer.ts
@@ -3,18 +3,18 @@ import {
   Context,
   DdcEvent,
   Item,
-} from "https://deno.land/x/ddc_vim@v3.7.0/types.ts";
+} from "https://deno.land/x/ddc_vim@v3.7.2/types.ts";
 import {
   Denops,
   fn,
   op,
   vars,
-} from "https://deno.land/x/ddc_vim@v3.7.0/deps.ts";
+} from "https://deno.land/x/ddc_vim@v3.7.2/deps.ts";
 import {
   GatherArguments,
   OnEventArguments,
-} from "https://deno.land/x/ddc_vim@v3.7.0/base/source.ts";
-import { vimoption2ts } from "https://deno.land/x/ddc_vim@v3.7.0/util.ts";
+} from "https://deno.land/x/ddc_vim@v3.7.2/base/source.ts";
+import { convertKeywordPattern } from "https://deno.land/x/ddc_vim@v3.7.2/util.ts";
 import { basename } from "https://deno.land/std@0.192.0/path/mod.ts";
 import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 
@@ -63,12 +63,7 @@ export class Source extends BaseSource<Params> {
       return;
     }
 
-    // Convert keywordPattern
-    const iskeyword = await op.iskeyword.getBuffer(denops, bufnr);
-    const bufPattern = pattern.replaceAll(
-      /\\k/g,
-      () => "[" + vimoption2ts(iskeyword) + "]",
-    );
+    const bufPattern = await convertKeywordPattern(denops, pattern, bufnr);
 
     this.buffers.set(info.bufnr, {
       bufnr: info.bufnr,

--- a/denops/@ddc-sources/buffer.ts
+++ b/denops/@ddc-sources/buffer.ts
@@ -127,16 +127,14 @@ export class Source extends BaseSource<Params> {
 
     return [...this.buffers.values()]
       .filter((cache) => bufnrs.includes(cache.bufnr))
-      .flatMap((cache): Item[] =>
-        cache.candidates.map((item) => ({
-          ...item,
-          menu: sourceParams.bufNameStyle === "full"
-            ? cache.bufname
-            : sourceParams.bufNameStyle === "basename"
-            ? basename(cache.bufname)
-            : undefined,
-        }))
-      );
+      .flatMap((cache): Item[] => {
+        const menu = sourceParams.bufNameStyle === "full"
+          ? cache.bufname
+          : sourceParams.bufNameStyle === "basename"
+          ? basename(cache.bufname)
+          : undefined;
+        return cache.candidates.map((item) => ({ ...item, menu }));
+      });
   }
 
   override params(): Params {


### PR DESCRIPTION
Sorry for the large patch.
If you need a smaller PR I will split it.

- Change internal container to `Map`.
- Proper error handling.
- Use `SourceOptions.keywordPattern` instead `Options.keywordPattern`.
- Fix error in `getbufinfo()`.

TODO:

- [x] (Done) Use `convertKeywordPattern()` instead `vimoption2ts`.
  - Waiting merge: [ddc.vim PR#128](https://github.com/Shougo/ddc.vim/pull/128)